### PR TITLE
Fix tests autoloading path

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,12 @@ addons:
 notifications:
   email:
   - team@appwrite.io
-  
+
 services:
 - docker
 
 install:
+- composer install --prefer-dist
 - >
     echo "80\n443\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n" | docker run --rm \
         --volume /var/run/docker.sock:/var/run/docker.sock \

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     },
     "autoload-dev": {
-        "psr-4": {"Tests\\E2E\\": "tests/e2e"}
+        "psr-4": {"Tests\\E2E\\": "tests/E2E"}
     },
     "require": {
         "php": ">=7.4.0",


### PR DESCRIPTION
The autoloading for test classes did not work correctly on case-sensitive filesystems. Changing the autoloading config for composer to be the same case as the actual path fixes this.

Previously, tests failed with "_Class not found_" error on case-sensitive file systems:

```
There was 1 error:

1) Tests\E2E\Services\Teams\FunctionsTest::testCreateProject
Error: Class 'Tests\E2E\Client' not found
```