### PR TITLE
Fix travis build missing dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,12 @@ addons:
 notifications:
   email:
   - team@appwrite.io
-  
+
 services:
 - docker
 
 install:
+- composer install --prefer-dist
 - >
     echo "80\n443\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n" | docker run --rm \
         --volume /var/run/docker.sock:/var/run/docker.sock \


### PR DESCRIPTION
This _should_ fix the phpunit call on travis build, though we'll see once the tests kick off.