### PR TITLE
Upgrade ruby version and dependencies

### DIFF
--- a/ruby/template/Gemfile
+++ b/ruby/template/Gemfile
@@ -1,5 +1,5 @@
-source "https://rubygems.org"
+source 'https://rubygems.org'
 
-ruby "~> 2.6.3"
+ruby '~> 3.0'
 
-gem 'appwrite', '~> 2.1', '>= 2.1.1'
+gem 'appwrite', '~> 2.4'


### PR DESCRIPTION
Noticed that default ruby version listed in `_APP_FUNCTIONS_RUNTIMES` and `_APP_FUNCTIONS_ENVS` is `3.0`.
Also new version `2.4` of `appwrite` gem is available.

Shouldn't we update ruby template to use latest dependencies?