### PR TITLE
Add GetCovidStats() function

### DIFF
--- a/dotnet/get-covid-stats/.gitignore
+++ b/dotnet/get-covid-stats/.gitignore
@@ -1,0 +1,40 @@
+*.swp
+*.*~
+project.lock.json
+.DS_Store
+*.pyc
+nupkg/
+
+# Visual Studio Code
+.vscode
+
+# Rider
+.idea
+
+# User-specific files
+*.suo
+*.user
+*.userosscache
+*.sln.docstates
+
+# Build results
+[Dd]ebug/
+[Dd]ebugPublic/
+[Rr]elease/
+[Rr]eleases/
+x64/
+x86/
+build/
+bld/
+[Bb]in/
+[Oo]bj/
+[Oo]ut/
+msbuild.log
+msbuild.err
+msbuild.wrn
+
+# Visual Studio 2015
+.vs/
+
+# Cloud Function Archive
+code.tar.gz

--- a/dotnet/get-covid-stats/GetCovidStats.csproj
+++ b/dotnet/get-covid-stats/GetCovidStats.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net5.0</TargetFramework>
+    <RootNamespace>GetCovidStats</RootNamespace>
+</PropertyGroup>
+
+</Project>

--- a/dotnet/get-covid-stats/Program.cs
+++ b/dotnet/get-covid-stats/Program.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace GetCovidStats
+{
+    class Program
+    {
+        async static Task Main(string[] args)
+        {
+            var country = Environment.GetEnvironmentVariable("COUNTRY_SLUG");
+            var dateFrom = DateTime.Today.AddDays(-1).ToString("yyyy-MM-ddThh:mm:ssZ");
+            var dateTo = DateTime.Today.AddDays(0).ToString("yyyy-MM-ddThh:mm:ssZ");
+            using (var client = new HttpClient())
+            {
+                if (string.IsNullOrEmpty(country))
+                {
+                    var req = await client.GetAsync($"https://api.covid19api.com/world?from={dateFrom}&to={dateTo}");
+                    Console.WriteLine(await req.Content.ReadAsStringAsync());
+                }
+                else
+                {
+                    var req = await client.GetAsync($"https://api.covid19api.com/live/country/{country}");
+                    Console.WriteLine(await req.Content.ReadAsStringAsync());
+                }
+            }
+        }
+    }
+}

--- a/dotnet/get-covid-stats/README.md
+++ b/dotnet/get-covid-stats/README.md
@@ -1,0 +1,34 @@
+# Check COVID today's status
+A sample .NET cloud function to give you COVID stats in Appwrite
+
+## 📝 Environment Variables
+Go to Settings tab of your Cloud Function. Add the following environment variables.
+
+* **COUNTRY_SLUG** - The country slug which COVID data you want to get
+
+## 🚀 Building and Packaging
+
+To package this example as a cloud function, follow these steps.
+
+```bash
+$ cd demos-for-functions/dotnet/get-covid-stats
+
+$ dotnet publish --runtime linux-x64 --framework net5.0 --no-self-contained
+```
+
+* Ensure that your output looks like this 
+```
+  GetCovidStats -> ......\demos-for-functions\dotnet\get-covid-stats\bin\Debug\net5.0\linux-x64\HelloWorld.dll
+  GetCovidStats -> ......\demos-for-functions\dotnet\get-covid-stats\bin\Debug\net5.0\linux-x64\publish\
+```
+
+* Create a tarfile
+
+```bash
+$ tar -C bin/Debug/net5.0/linux-x64 -zcvf code.tar.gz publish
+```
+
+* Navigate to the Overview Tab of your Cloud Function > Deploy Tag
+* Input the command that will run your function (in this case `dotnet GetCovidStats.dll`) as your entrypoint command
+* Upload your tarfile 
+* Click 'Activate'


### PR DESCRIPTION
## What does this PR do?
It implements the GetCovidStats() function in .NET.
If a country slug is informed as ENVIRONMENT VARIABLE, retrieves the COVID data of this country.
If no country slug is provided, retrieves global COVID data.

## Test Plan
Add a new Function on Appwrite, configure a publish file as described on README.md and execute the function.

## Related PRs and Issues
Implementation of the issue https://github.com/appwrite/appwrite/issues/1923