### PR TITLE
Implement GenerateUnsplashImage() on .NET

### DIFF
--- a/dotnet/generate-unsplash-image/.gitignore
+++ b/dotnet/generate-unsplash-image/.gitignore
@@ -1,0 +1,40 @@
+*.swp
+*.*~
+project.lock.json
+.DS_Store
+*.pyc
+nupkg/
+
+# Visual Studio Code
+.vscode
+
+# Rider
+.idea
+
+# User-specific files
+*.suo
+*.user
+*.userosscache
+*.sln.docstates
+
+# Build results
+[Dd]ebug/
+[Dd]ebugPublic/
+[Rr]elease/
+[Rr]eleases/
+x64/
+x86/
+build/
+bld/
+[Bb]in/
+[Oo]bj/
+[Oo]ut/
+msbuild.log
+msbuild.err
+msbuild.wrn
+
+# Visual Studio 2015
+.vs/
+
+# Cloud Function Archive
+code.tar.gz

--- a/dotnet/generate-unsplash-image/GenerateUnsplashImage.csproj
+++ b/dotnet/generate-unsplash-image/GenerateUnsplashImage.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net5.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/dotnet/generate-unsplash-image/Program.cs
+++ b/dotnet/generate-unsplash-image/Program.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading.Tasks;
+
+namespace GenerateUnsplashImage
+{
+    class Program
+    {
+        private static string UnsplashApiUrl = "https://api.unsplash.com/search/photos";
+        static async Task Main(string[] args)
+        {
+            var keyword = Environment.GetEnvironmentVariable("UNSPLASH_KEYWORD");
+            var accessKey = Environment.GetEnvironmentVariable("UNSPLASH_ACCESS_KEY");
+
+            using (var client = new HttpClient())
+            {
+                client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Client-ID", accessKey);
+                var req = await client.GetAsync($"{UnsplashApiUrl}?query={keyword}&per_page=1");
+                var strigContent = await req.Content.ReadAsStringAsync();
+                var result = JsonSerializer.Deserialize<UnsplashSearchResult>(strigContent);
+                Console.WriteLine($"Image URL: {result.Results.First().Links.Download}");
+                Console.WriteLine($"Image Author: {result.Results.First().User.Name}");
+            }
+        }
+    }
+
+    public class UnsplashSearchResult
+    {
+        [JsonPropertyName("results")]
+        public List<UnsplashResult> Results { get; set; }
+    }
+
+    public class UnsplashResult
+    {
+        [JsonPropertyName("links")]
+        public Link Links { get; set; }
+        [JsonPropertyName("user")]
+        public User User { get; set; }
+    }
+
+    public class Link
+    {
+        [JsonPropertyName("download")]
+        public string Download { get; set; }
+    }
+
+    public class User
+    {
+        [JsonPropertyName("name")]
+        public string Name { get; set; }
+    }
+}

--- a/dotnet/generate-unsplash-image/README.md
+++ b/dotnet/generate-unsplash-image/README.md
@@ -1,0 +1,45 @@
+# Get Image Url and Image Author from Unsplash API
+A sample .NET cloud function to retrieve an Image Url and Author based on a keyword
+
+## 📝 Environment Variables
+Go to Settings tab of your Cloud Function. Add the following environment variables.
+
+* **UNSPLASH_KEYWORD** - The keyword you want to search
+* **UNSPLASH_ACCESS_KEY** - The Access Key for your Unsplash Application
+
+## 📝 Creating an Unsplash Application
+First, you have to setup a Developer Account on this link:
+https://unsplash.com/join
+
+Once you're logged in, go to https://unsplash.com/oauth/applications and click on New Application.
+
+After creating your application, copy your Access Key and Secret Key to a safe place.
+
+For more information, please, go to the Unsplash Documentation
+https://unsplash.com/documentation#creating-a-developer-account
+
+## 🚀 Building and Packaging
+
+To package this example as a cloud function, follow these steps.
+
+```bash
+$ cd demos-for-functions/dotnet/generate-unsplash-image
+$ dotnet publish --runtime linux-x64 --framework net5.0 --no-self-contained
+```
+
+* Ensure that your output looks like this 
+```
+  GenerateUnsplashImage -> ......\demos-for-functions\dotnet\generate-unsplash-image\bin\Debug\net5.0\linux-x64\HelloWorld.dll
+  GenerateUnsplashImage -> ......\demos-for-functions\dotnet\generate-unsplash-image\bin\Debug\net5.0\linux-x64\publish\
+```
+
+* Create a tarfile
+
+```bash
+$ tar -C bin/Debug/net5.0/linux-x64 -zcvf code.tar.gz publish
+```
+
+* Navigate to the Overview Tab of your Cloud Function > Deploy Tag
+* Input the command that will run your function (in this case `dotnet GenerateUnsplashImage.dll`) as your entrypoint command
+* Upload your tarfile 
+* Click 'Activate'


### PR DESCRIPTION
## What does this PR do?
It implements the GenerateUnsplashImage() function on .NET.
Two environment variables are required: UNSPLASH_KEYWORD and UNSPLASH_ACCESS_KEY.
The UNSPLASH_KEYWORD will be used to search for an Image on Unsplash API.
The UNSPLASH_ACCESS_KEY will be user for Authentication on the API.

## Test Plan
Add a new Function on Appwrite, configure a publish file as described on README.md and execute the function.

## Related PRs and Issues
Implementation of the issue https://github.com/appwrite/appwrite/issues/1908