### PR TITLE
 Feat addUpdatedAt: implements add updated at in python

### DIFF
--- a/python/add-updated-at/README.md
+++ b/python/add-updated-at/README.md
@@ -1,0 +1,66 @@
+# Add Updated At
+
+A sample Python Cloud Function that trigger on `database.documents.update` event and fill `updatedAt` attribute with the current unix timestamp (in seconds), if this rule for `updatedAt` is configured on a specific collection.
+
+## 📝 Environment Variables
+
+Go to Settings tab of your Cloud Function. Add the following environment variables.
+
+- **APPWRITE_ENDPOINT** - Your Appwrite Project Endpoint ( can be found at `settings` tab on your Appwrite console)
+- **APPWRITE_FUNCTION_PROJECT_ID** - Your Appwrite Project Id ( can be found at `settings` tab on your Appwrite console)
+- **APPWRITE_API_KEY** - Your Appwrite Project API Keys ( can be found at `API Keys` tab on your Appwrite console). Create a key with the scope (`documents.write`)
+
+## 🚀 Building and Packaging
+
+To package this example as a cloud function, follow these steps:
+
+```bash
+$ cd demos-for-functions/python/add-updated-at
+$ PIP_TARGET=./.appwrite pip install -r ./requirements.txt --upgrade --ignore-installed
+```
+
+Ensure that your folder structure looks like this
+
+```text
+.
+├── .appwrite/
+├── main.py
+└── requirements.txt
+```
+
+Create a tarfile
+
+```bash
+$ cd ..
+$ tar -zcvf code.tar.gz add-updated-at
+```
+
+Upload the tarfile to your Appwrite Console and use the following entrypoint command
+
+```bash
+python main.py
+```
+
+## 💽 Database
+
+Go to Database tab and follow these steps:
+
+- Add new Collection, then database collection settings will popup
+- At the Rules section, click `Add` 
+- Fill `updatedAt` as the `Key` & `Label`
+- Set the `Rule Type` to text and click `Create`
+- Update the settings by clicking `Update` button
+- Go to Documents tab and click `Add Document`
+- Fill in the data needed and click create
+- There should be `Document ID` and `Collection ID` on the right side (we need both of this as data when triggering cloud functions)
+
+PS: You can add as many rules as wanted, we just need `updatedAt` key to see the cloud function woking
+
+## 🎯 Trigger
+
+- Head over to your function in the Appwrite console and under the Settings Tab, enable the `database.documents.update` event.
+- See the result at Logs
+
+## 📓 Note
+
+- If `APPWRITE_ENDPOINT` is localhost, error might occur `Failed to connect to localhost/127.0.0.1:80)`, to test it locally try to use services like `ngrok` which provide tunneling to localhost.

--- a/python/add-updated-at/main.py
+++ b/python/add-updated-at/main.py
@@ -1,0 +1,41 @@
+import os
+import json
+import time
+
+from appwrite.client import Client
+from appwrite.services.database import Database
+
+
+def init_client():
+    # Initialize the Appwrite client
+    client = Client()
+    client.set_endpoint(os.getenv("APPWRITE_ENDPOINT"))
+    client.set_project(os.getenv("APPWRITE_FUNCTION_PROJECT_ID"))
+    client.set_key(os.getenv("APPWRITE_API_KEY"))
+
+    return client
+
+def main():
+    payload = json.loads(os.getenv("APPWRITE_FUNCTION_EVENT_DATA"))
+
+    UPDATED_AT_KEY = "updatedAt"
+    collectionId = payload["$collection"]
+    documentId = payload["$id"]
+    currentTimeStamp = time.time()
+
+    if UPDATED_AT_KEY not in payload:
+        return
+
+    client = init_client()
+    database = Database(client)
+
+    database.update_document(
+        collectionId,
+        documentId,
+        {UPDATED_AT_KEY: currentTimeStamp},
+    )
+    
+    print("Updated the field updatedAt with current timestamp successfully.")
+
+if __name__ == "__main__":
+    main()

--- a/python/add-updated-at/requirements.txt
+++ b/python/add-updated-at/requirements.txt
@@ -1,0 +1,1 @@
+appwrite


### PR DESCRIPTION
This PR:
- implements add updated at in python
- Resolves https://github.com/appwrite/appwrite/issues/1900

/cc @Meldiron 

Created a document without `updatedAt` value
![Screenshot from 2021-10-09 08-47-47](https://user-images.githubusercontent.com/74595610/136645968-b4588801-f295-4220-a52d-066ba7965636.png)

No value for `updatedAt` field
![Screenshot from 2021-10-09 08-48-29](https://user-images.githubusercontent.com/74595610/136645993-46432767-1269-4068-b06e-6486a6a55f0b.png)

Now executed my function
![Screenshot from 2021-10-09 11-26-16](https://user-images.githubusercontent.com/74595610/136646028-bf0f6269-43f3-4821-84cd-ba6bf863197b.png)

Logs after successful execution
![Screenshot from 2021-10-09 11-13-20](https://user-images.githubusercontent.com/74595610/136646005-ed07467b-61e0-41b4-8452-2d4d2193d2f8.png)

`updatedAt` field got set with current timestamp
![Screenshot from 2021-10-09 11-13-34](https://user-images.githubusercontent.com/74595610/136646049-64ebf19b-f7f4-4a53-bbd6-5bad55c49605.png)