### PR TITLE
Add common rules to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,13 +1,11 @@
 vendor
 
-nodejs/welcome-email/node_modules
-nodejs/welcome-email/package-lock.json
-nodejs/code.tar.gz
-deno/code.tar.gz
+nodejs/**/node_modules
+nodejs/**/package-lock.json
 dart/**/.dart_tool
 dart/**/.packages
 dart/**/pubspec.lock
-dart/**/.appwrite
 python/**/__pycache__
-python/**/.appwrite
+**/.appwrite
+**/code.tar.gz
 *.DS_Store


### PR DESCRIPTION
Extract common rules in `.gitignore`:
 * According to [documentation](https://appwrite.io/docs/functions) examples for `dart`, `python`, `ruby`, `deno` can contain subdir `.appwrite`, so we can replace single rules with common pattern to ignore them all
 * As I can see, it is kind of convention to name archives with builds as `code.tar.gz`
 * Inside `nodejs` replace example-level rule with common pattern