### PR TITLE
add dart code example to compress image and store it in appwrite storage

### DIFF
--- a/dart/compress-tinypng-image/README.md
+++ b/dart/compress-tinypng-image/README.md
@@ -1,0 +1,49 @@
+# 📧 Compress and Save image to Appwrite storage with given image url
+A sample Dart Cloud Function to compress and save image to Appwrite storage with given image url.
+
+## ☁️ Make a New Cloud Function
+Navigate to 'Functions' and 'Add Function.'
+Use 'Dart 2.13' environment.
+
+## 📝 Environment Variables
+Go to Settings tab of your Cloud Function. Add the following environment variables.
+
+* **TINYPNG_API_KEY** - API Key for Tinypng 
+* **API_ENDPOINT** - Appwrite API endpoint
+* **API_SECRET** - Appwrite API Key
+* **APP_FUNCTION_DATA** - Image URL to compress and save
+
+## 🚀 Building and Packaging
+To package this example as a cloud function, follow these steps.
+
+```bash
+$ cd demos-for-functions/dart/compress-tinypng-image
+```
+
+* Ensure that your folder structure looks like this 
+```
+.
+├── pubsec.yaml
+└── compress.dart
+```
+
+* Compile code
+```bash
+$ dart pub get
+$ dart compile exe compress.dart
+```
+* Create a tarfile
+
+```bash
+$ cd ..
+$ tar -zcvf code.tar.gz compress-tinypng-image
+```
+
+* Navigate to Overview Tab of your Cloud Function
+* Deploy Tag
+* Input the command that will run your function (in this case "./compress.exe") as your entrypoint command
+* Upload your tarfile 
+* Click 'Activate'
+
+## 🎯 Trigger
+Head over to your function in the Appwrite console and under the Settings Tab, enable relevant events or schedule.

--- a/dart/compress-tinypng-image/compress.dart
+++ b/dart/compress-tinypng-image/compress.dart
@@ -1,0 +1,74 @@
+import 'dart:io';
+
+import 'package:http/http.dart' as http;
+import 'dart:convert';
+import 'package:dart_appwrite/dart_appwrite.dart';
+
+void compressAndStore(String sourceUrl) async {
+  try {
+    var url = Uri.parse("https://api.tinify.com/shrink");
+    // String tinyPNGApiKey = "zDm5Pb08BxphdRZp4ndw0vnvqVTSXlWl";
+    String tinyPNGApiKey = Platform.environment['TINYPNG_API_KEY'];
+    String base64Encoded = base64.encode(utf8.encode('api:$tinyPNGApiKey'));
+
+    Map data = {
+      "source": {"url": sourceUrl}
+    };
+
+    String body = jsonEncode(data);
+    var header = {
+      'Authorization': 'Basic $base64Encoded',
+      'Content-Type': 'application/json'
+    };
+    // print(header)
+
+    // Compress Image
+    http.Response response = await http.post(
+      url,
+      headers: header,
+      body: body,
+    );
+
+    // print(response.body)
+
+    // if(response.statusCode != 200) throw new Error(response.body);
+
+    // get Download Url recieved in resonse for compress image
+    var decodedData = jsonDecode(response.body) as Map;
+    var downloadUrl = Uri.parse(decodedData['output']['url']);
+
+    // get compress image from download url
+    http.Response compressImageResponse = await http.get(
+      downloadUrl,
+      headers: header,
+    );
+
+    // init Dart SDK
+    Client client = Client();
+    Storage storage = Storage(client);
+
+    client
+        .setEndpoint(Platform.environment['API_ENDPOINT']) // Your API Endpoint
+        .setProject(Platform
+            .environment['APPWRITE_FUNCTION_PROJECT_ID']) // Your project ID
+        .setKey(Platform.environment['API_SECRET']); // Your secret API key
+
+    // Store File Appwrite Storage
+
+    var result = await storage.createFile(
+      file: MultipartFile.fromBytes('file', compressImageResponse.bodyBytes,
+          filename: DateTime.now().toString()),
+    );
+
+    print(result.data);
+    exit(0);
+  } catch (err) {
+    print(err);
+    exit(0);
+  }
+}
+
+void main() {
+  String exampleSourceURL = Platform.environment['APPWRITE_FUNCTION_DATA'];
+  compressAndStore(exampleSourceURL);
+}

--- a/dart/compress-tinypng-image/pubspec.yaml
+++ b/dart/compress-tinypng-image/pubspec.yaml
@@ -1,0 +1,12 @@
+name: compressTinypngImage
+version: 1.0.0
+description: >-
+  Compress image using tinypng api
+environment:
+  sdk: '>=2.10.0 <3.0.0'
+dependencies:
+  dart_appwrite: ^1.0.1
+  http: ^0.13.4
+
+dev_dependencies:
+  test: '>=1.15.0 <2.0.0'


### PR DESCRIPTION
 Resolves:https://github.com/appwrite/appwrite/issues/1924

##  Environment Variables

* **TINYPNG_API_KEY** - API Key for Tinypng 
* **API_ENDPOINT** - Appwrite API endpoint
* **API_SECRET** - Appwrite API Key
* **APP_FUNCTION_DATA** - Image URL to compress and save 

## Executed Function
![image1](https://user-images.githubusercontent.com/60872915/136760991-1cf7941f-a5f6-4d46-be34-243549ed534c.jpeg)

## Uploaded File in Storage
![image2](https://user-images.githubusercontent.com/60872915/136761040-c7320bd8-19cf-4c24-885b-f2099b65e062.jpeg)


