### PR TITLE
feat: implement subscribe to sendgrid

### DIFF
--- a/dart/subscribe_to_send_grid/README.md
+++ b/dart/subscribe_to_send_grid/README.md
@@ -1,0 +1,47 @@
+# 📧 Add an email to SendGrid list
+
+A sample Dart Cloud Function for adding the given email address to a Sendgrid contact list.
+
+## 📝 Environment Variables
+
+Go to Settings tab of your Cloud Function. Add the following environment variables.
+
+- **SENDGRID_API_KEY** - Your Sendgrid API key
+- **NEWSLETTER_LIST_ID** - List ID of the list the email should be added to.
+
+## 🚀 Building and Packaging
+
+To package this example as a cloud function, follow these steps.
+
+```bash
+$ cd demos-for-functions/dart/subscribe_to_send_grid
+
+$ PUB_CACHE=.appwrite/ dart pub get
+```
+
+- Ensure that your folder structure looks like this
+
+```
+.
+├── .appwrite/
+├── main.dart
+├── pubspec.lock
+└── pubspec.yaml
+```
+
+- Create a tarfile
+
+```bash
+$ cd ..
+$ tar -zcvf code.tar.gz subscribe_to_sendgrid
+```
+
+- Navigate to the Overview Tab of your Cloud Function > Deploy Tag
+- Input the command that will run your function (in this case "dart main.dart") as your entrypoint command
+- Upload your tarfile
+- Click 'Activate'
+
+## 🎯 Trigger
+
+Head over to your function in the Appwrite console and click `Execute Now`. In the Custom Data field, input the mail address you want to add to the list.
+This will cause the function to triggered whenever any user is created on the app, and their email will be added to the list specified.

--- a/dart/subscribe_to_send_grid/main.dart
+++ b/dart/subscribe_to_send_grid/main.dart
@@ -1,0 +1,61 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:http/http.dart' as http;
+
+String ensureEnvVariable(String key) {
+  final value = Platform.environment[key];
+  if (value == null) {
+    print(
+        'Could not find environment variable $key. Please set it following the instructions in the readme file.');
+    exit(1);
+  }
+
+  return value;
+}
+
+// Dart by default appends a charset to the Content-Type while SendGrid rejects
+//  exactly that. By using this client, we can force a clean content type.
+class CleanContentTypeClient extends http.BaseClient {
+  final http.Client _inner;
+  final String _contentType;
+
+  CleanContentTypeClient(this._contentType, this._inner);
+
+  Future<http.StreamedResponse> send(http.BaseRequest request) {
+    request.headers['Content-Type'] = _contentType;
+    return _inner.send(request);
+  }
+}
+
+void main() async {
+  final email = Platform.environment['APPWRITE_FUNCTION_DATA']!;
+  final sendgridApiKey = ensureEnvVariable('SENDGRID_API_KEY');
+  final newsletterListId = ensureEnvVariable('SENDGRID_NEWSLETTER_ID');
+
+  final url = Uri.parse('https://api.sendgrid.com/v3/marketing/contacts');
+  final headers = {
+    'Authorization': 'Bearer $sendgridApiKey',
+  };
+  final body = {
+    'list_ids': [newsletterListId],
+    'contacts': [
+      {"email": email}
+    ],
+  };
+
+  final client = http.Client();
+  final contentTypeClient = CleanContentTypeClient('application/json', client);
+  final response = await contentTypeClient.put(
+    url,
+    headers: headers,
+    body: jsonEncode(body),
+  );
+  if (response.statusCode != 202) {
+    print(
+        'Error adding contact to list! ${response.statusCode} ${response.body}');
+    exit(1);
+  }
+
+  print('Successfully queued contact to be added to the list!');
+}

--- a/dart/subscribe_to_send_grid/pubspec.yaml
+++ b/dart/subscribe_to_send_grid/pubspec.yaml
@@ -1,0 +1,9 @@
+name: subscribe_to_send_grid
+description: A demo application to showcase subscribing to sendgrid through an Appwrite function.
+
+environment:
+  sdk: '>=2.12.0 <2.13.0'
+
+dependencies:
+  dart_appwrite: ^1.0.1
+  http: ^0.13.3


### PR DESCRIPTION
Implements adding an email address to a sendgrid contact list following https://github.com/appwrite/appwrite/issues/1915.

![Screenshot of the Execute Now dialog containing the email "this-is-an@example.com"](https://user-images.githubusercontent.com/26303198/138517864-e7a6c2b7-b84e-4a78-bb11-acc62b730b03.png)

![Screenshots of logs indicating success](https://user-images.githubusercontent.com/26303198/138519125-c83d36f2-ae9a-4509-95cd-89670b8df86f.png)

![Screenshot of the SendGrid Contact list with the email added](https://user-images.githubusercontent.com/26303198/138519183-1fad1f32-f4b1-458c-8125-2c50387934e4.png)
