### PR TITLE
feat: implement generateOpenStreetMap in dart

### DIFF
--- a/dart/generate_open_street_map/README.md
+++ b/dart/generate_open_street_map/README.md
@@ -1,0 +1,53 @@
+# 🗂 Generate Open Street Maps
+A sample Dart Cloud Function that saves an open street maps tile for given latitude and longitude to Appwrite storage.
+
+## 📝 Environment Variables
+Add the following environment variables in your Cloud Function settings.
+
+* **APPWRITE_API_KEY** - Create a key from the Appwrite console with the following scope (`files.write`)
+* **APPWRITE_ENDPOINT** - Your Appwrite Endpoint
+
+## 🚀 Building and Packaging
+
+To package this example as a cloud function, follow these steps.
+
+```bash
+$ cd demos-for-functions/dart/generate_open_street_map
+
+$ PUB_CACHE=.appwrite/ dart pub get
+```
+
+* Ensure that your folder structure looks like this 
+```
+.
+├── .appwrite/
+├── main.dart
+├── pubspec.lock
+└── pubspec.yaml
+```
+
+* Create a tarfile
+
+```bash
+$ cd ..
+$ tar -zcvf code.tar.gz generate_open_street_map
+```
+
+* Upload the tarfile to your Appwrite Console and use the following entrypoint command
+
+```bash
+dart main.dart
+```
+
+## 🎯 Trigger
+
+Head over to your function in the Appwrite console and after clicking the `Execute Now` button, enter a JSON object in the form of
+```json
+{
+  "latitude": 37.7822403,
+  "longitude": -122.3910414
+}
+```
+with your respective coordinates.
+
+If your function errors out with code 124, increase the timeout under the Settings Tab.

--- a/dart/generate_open_street_map/main.dart
+++ b/dart/generate_open_street_map/main.dart
@@ -1,0 +1,69 @@
+import 'dart:convert';
+import 'dart:math';
+import 'dart:io';
+
+import 'package:http/http.dart' as http;
+import 'package:dart_appwrite/dart_appwrite.dart';
+import 'package:vector_math/vector_math.dart';
+
+const zoomLevel = 15;
+
+String ensureEnvVariable(String key) {
+  final value = Platform.environment[key];
+  if (value == null) {
+    print(
+        'Could not find environment variable $key. Please set it following the instructions in the readme file.');
+    exit(1);
+  }
+
+  return value;
+}
+
+// Adapted from https://wiki.openstreetmap.org/wiki/Slippy_map_tilenames#Mathematics
+Point<int> coordinatesToTilePoint(double latitude, double longitude) {
+  final x = (pow(2, zoomLevel) * ((longitude + 180) / 360)).floor();
+
+  final radLat = radians(latitude);
+  final y = (pow(2, zoomLevel - 1) *
+          (1 - (log(tan(radLat) + (1 / cos(radLat))) / pi)))
+      .floor();
+
+  return Point(x, y);
+}
+
+Future<List<int>> fetchTile(double latitude, double longitude) async {
+  final point = coordinatesToTilePoint(latitude, longitude);
+  final tileUrl =
+      'https://tile.openstreetmap.org/${zoomLevel}/${point.x}/${point.y}.png';
+
+  print(tileUrl);
+
+  final response = await http.get(Uri.parse(tileUrl));
+  if (response.statusCode != 200) {
+    print('There was an error loading the tile for $point: ${response.body}');
+    exit(1);
+  }
+
+  return response.bodyBytes;
+}
+
+void main() async {
+  final client = Client();
+  client
+      .setKey(ensureEnvVariable('APPWRITE_API_KEY'))
+      .setProject(ensureEnvVariable('APPWRITE_FUNCTION_PROJECT_ID'))
+      .setEndpoint(ensureEnvVariable('APPWRITE_ENDPOINT'));
+
+  final data = jsonDecode(ensureEnvVariable('APPWRITE_FUNCTION_DATA'));
+
+  final storage = Storage(client);
+  final latitude = data['latitude'];
+  final longitude = data['longitude'];
+
+  final imageBytes = await fetchTile(latitude, longitude);
+  final filename = 'osm_tile_${latitude}_${longitude}_z$zoomLevel.png';
+
+  await storage.createFile(
+    file: MultipartFile.fromBytes('file', imageBytes, filename: filename),
+  );
+}

--- a/dart/generate_open_street_map/pubspec.yaml
+++ b/dart/generate_open_street_map/pubspec.yaml
@@ -1,0 +1,10 @@
+name: generate_open_street_map
+description: An example implementation of saving an OpenStreetMaps tile to Storage given latitude and longitude
+version: 1.0.0
+
+environment:
+  sdk: '>=2.12.0 <2.13.0'
+
+dependencies:
+  dart_appwrite: ^1.0.1
+  vector_math: ^2.1.0


### PR DESCRIPTION
Implements the generateOpenStreetMap example cloud function in dart following https://github.com/appwrite/appwrite/issues/1920.

Screenshots:

![Screenshot of the Execute Now screen with a JSON object defining latitude and longitude](https://user-images.githubusercontent.com/26303198/138514513-7aa65cb3-bec5-4540-aac9-ddfccd743b9a.png)

![Standard Output showing the URL of the requested tile](https://user-images.githubusercontent.com/26303198/138514587-96b3faaa-caec-4214-bd0f-73ccfc04fab8.png)

![Screenshot showing the tile PNG in storage](https://user-images.githubusercontent.com/26303198/138514659-10b7e2a0-aff4-4612-8485-869ff54b9392.png)
