### PR TITLE
Feat implement generate bitly url dotnet

### DIFF
--- a/dotnet/generate-bitly-url/GenerateBitlyURL.csproj
+++ b/dotnet/generate-bitly-url/GenerateBitlyURL.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net5.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+  </ItemGroup>
+
+</Project>

--- a/dotnet/generate-bitly-url/Program.cs
+++ b/dotnet/generate-bitly-url/Program.cs
@@ -1,0 +1,55 @@
+﻿using Newtonsoft.Json.Linq;
+using System;
+using System.IO;
+using System.Net;
+
+namespace GenerateBitlyURL
+{
+    class Program
+    {
+
+        static void Main(string[] args)
+        {
+            string url = Environment.GetEnvironmentVariable("APPWRITE_FUNCTION_DATA");
+            string token = Environment.GetEnvironmentVariable("BITLY_ACCESS_TOKEN");
+
+            Console.WriteLine(GenerateBitlyURL(url, token));
+        }
+
+        public static string GenerateBitlyURL(string urlToGenerate, string token)
+        {
+            try
+            {
+                var url = "https://api-ssl.bitly.com/v4/shorten";
+
+                var httpRequest = (HttpWebRequest)WebRequest.Create(url);
+                httpRequest.Method = "POST";
+
+                httpRequest.Headers["Authorization"] = "Bearer " + token;
+                httpRequest.ContentType = "application/json";
+
+                var data = "{\"long_url\": \"" + urlToGenerate + "\"}";
+
+                using (var streamWriter = new StreamWriter(httpRequest.GetRequestStream()))
+                {
+                    streamWriter.Write(data);
+                }
+
+                var httpResponse = (HttpWebResponse)httpRequest.GetResponse();
+                string content = "";
+                using (var streamReader = new StreamReader(httpResponse.GetResponseStream()))
+                {
+                    content = streamReader.ReadToEnd();
+                }
+
+                JObject jsonObject = JObject.Parse(content);
+                return jsonObject["link"].ToString();
+            }
+            catch(Exception ex)
+            {
+                return "Error: " + ex.Message;
+            }
+        }
+
+    }
+}

--- a/dotnet/generate-bitly-url/README.md
+++ b/dotnet/generate-bitly-url/README.md
@@ -1,0 +1,43 @@
+# ⛓ Generate shorter URL from bitly
+
+Function to generate shorter URL address from address via [Bitly](https://bitly.com).
+
+## 📝 Environment Variables
+
+Go to Settings tab of your Cloud Function. Add the following environment variables.
+
+* **APPWRITE_FUNCTION_DATA** - URL Addres to generate
+* **BITLY_ACCESS_TOKEN** - Bitly bearer token
+
+## 🚀 Building and Packaging
+
+To package this example as a cloud function, follow these steps.
+
+```bash
+$ cd demos-for-functions/dotnet/generate-bitly-url
+
+$ dotnet publish --runtime linux-x64 --framework net5.0 --no-self-contained
+```
+
+* Ensure that your output looks like this 
+
+```
+  GenerateBitlyURL -> ......\demos-for-functions\dotnet\generate-bitly-url\bin\Debug\net5.0\linux-x64\GenerateBitlyURL.dll
+  GenerateBitlyURL -> ......\demos-for-functions\dotnet\generate-bitly-url\bin\Debug\net5.0\linux-x64\publish\
+```
+
+* Create a tarfile
+
+```bash
+$ tar -C bin/Debug/net5.0/linux-x64 -zcvf code.tar.gz publish
+```
+
+* Navigate to the Overview Tab of your Cloud Function > Deploy Tag
+* Input the command that will run your function (in this case `dotnet GenerateBitlyURL.dll`) as your entrypoint command
+* Upload your tarfile 
+* Click 'Activate'
+
+## 🎯 Trigger
+
+You trigger the function by manually executing it in the Appwrite console (Excetute Now) or by using SDK (excetuteFunction).
+


### PR DESCRIPTION
<img src="https://cdn.discordapp.com/attachments/523565746350194688/901110061819129956/CleanShot_2021-10-22_at_16.09.27.png">
<img src="https://cdn.discordapp.com/attachments/523565746350194688/901110066156036176/CleanShot_2021-10-22_at_16.09.30.png">

I made generate bitly url function in dotnet. Function using [Newtonsoft.Json](https://www.newtonsoft.com/json) for easier mapping response from bitly.
My function needs 2 enviroment variables

APPWRITE_FUNCTION_DATA - stands for URL that you want to short
BITLY_ACCESS_TOKEN - stands for your bitly bearer token
And returns just bitly url (for example: `bit.ly/3vwtREE`)