### PR TITLE
mergeCloudConvertFiles(): Add Kotlin implementation

### DIFF
--- a/kotlin/merge-cloud-convert-files/.gitignore
+++ b/kotlin/merge-cloud-convert-files/.gitignore
@@ -1,0 +1,12 @@
+.gradle
+**/build/
+!src/**/build/
+
+# Ignore Gradle GUI config
+gradle-app.setting
+
+# Avoid ignoring Gradle wrapper jar file (.jar files are usually ignored)
+!gradle-wrapper.jar
+
+# Cache of project
+.gradletasknamecache

--- a/kotlin/merge-cloud-convert-files/README.md
+++ b/kotlin/merge-cloud-convert-files/README.md
@@ -1,0 +1,56 @@
+# 🦠 Merging Files Into A Single PDF Using CloudConvert
+
+A sample Kotlin Cloud Function for merging at least two files into one PDF using CloudConvert. If input files are not
+PDFs yet, they are automatically converted to PDF.
+
+## 📝 Environment Variables
+
+Go to Settings tab of your Cloud Function. Add the following environment variables.
+
+- **APPWRITE_ENDPOINT** - Mandatory. Your Appwrite Endpoint
+- **APPWRITE_API_KEY** - Mandatory. Your Appwrite API key with `files.read` and `files.write` permissions
+- **CLOUDCONVERT_API_KEY** - Mandatory. Your CloudConvert API key with `task.read` and `task.write` permissions. Created
+  through Authorization > API Keys on Dashboard
+- **CLOUDCONVERT_SANDBOX** - Optional. `true` to use Sandbox API instead of Live API. Defaults to `false`.
+
+## 🚀 Building and Packaging
+
+To package this example as a cloud function, follow these steps.
+
+- Create a tarfile
+
+```bash
+gradle shadowDistTar
+```
+
+(the tarfile is created in `build/distributions`)
+
+- Navigate to the Overview Tab of your Cloud Function > Deploy Tag
+- Input the command that will run your function (in this
+  case `java -jar lib/merge-cloud-convert-files-1.0.0-SNAPSHOT-all.jar`) as your entrypoint command
+- Upload your tarfile
+- Click `Activate`
+
+## 🎯 Trigger
+
+Head over to your function in the Appwrite console and under the Overview Tab, click Execute Now and supply the function
+data in JSON format, eg.
+
+```json
+{
+  "fileIds": [
+    "FILE_ID_1",
+    "FILE_ID_2"
+  ],
+  "outputFileName": "merged.pdf"
+}
+```
+
+### Parameters:
+
+- **fileIds** - Mandatory. IDs of files in Appwrite Storage to merge.
+- **engine** - Optional. Engine for the conversion (see https://cloudconvert.com/api/v2/merge#merge-tasks for the list
+  of options)
+- **engineVersion** - Optional. Engine version for the conversion (see https://cloudconvert.com/api/v2/merge#merge-tasks
+  for the list of options)
+- **outputFileName** - Optional. Name of output file (including extension).

--- a/kotlin/merge-cloud-convert-files/build.gradle.kts
+++ b/kotlin/merge-cloud-convert-files/build.gradle.kts
@@ -1,0 +1,46 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
+plugins {
+    kotlin("jvm") version "1.5.31"
+    kotlin("plugin.serialization") version "1.5.31"
+    application
+    id("com.github.johnrengelman.shadow") version "7.1.0"
+}
+
+group = "io.appwrite"
+version = "1.0.0-SNAPSHOT"
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation("io.appwrite:sdk-for-kotlin:0.1.0")
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.3.0")
+    implementation("com.cloudconvert:cloudconvert-java:1.0.7")
+    implementation("org.slf4j:slf4j-simple:1.7.32")
+}
+
+tasks.withType<KotlinCompile>().configureEach {
+    // required to use kotlinx.serialization's Json#decodeFromStream(InputStream)
+    kotlinOptions.freeCompilerArgs += "-Xopt-in=kotlin.RequiresOptIn"
+}
+
+application {
+    mainClass.set("io.appwrite.merge.cloud.convert.files.ApplicationKt")
+}
+
+tasks.withType<Tar>() {
+    compression = Compression.GZIP
+    archiveExtension.set("tar.gz")
+}
+
+tasks {
+    shadowJar {
+        minimize {
+            // required by com.cloudconvert:cloudconvert-java
+            exclude(dependency("commons-logging:commons-logging"))
+            exclude(dependency("com.fasterxml.jackson.*:.*"))
+        }
+    }
+}

--- a/kotlin/merge-cloud-convert-files/gradle.properties
+++ b/kotlin/merge-cloud-convert-files/gradle.properties
@@ -1,0 +1,1 @@
+kotlin.code.style=official

--- a/kotlin/merge-cloud-convert-files/settings.gradle.kts
+++ b/kotlin/merge-cloud-convert-files/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "merge-cloud-convert-files"

--- a/kotlin/merge-cloud-convert-files/src/main/kotlin/io/appwrite/merge/cloud/convert/files/Application.kt
+++ b/kotlin/merge-cloud-convert-files/src/main/kotlin/io/appwrite/merge/cloud/convert/files/Application.kt
@@ -1,0 +1,93 @@
+package io.appwrite.merge.cloud.convert.files
+
+import io.appwrite.Client
+import io.appwrite.merge.cloud.convert.files.model.AppwriteFile
+import io.appwrite.merge.cloud.convert.files.model.FunctionData
+import io.appwrite.merge.cloud.convert.files.model.storage.FileMetadata
+import io.appwrite.services.Storage
+import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.decodeFromStream
+import kotlin.system.exitProcess
+
+fun main() {
+    try {
+        Application.run()
+    } catch (exception: Exception) {
+        exception.printStackTrace()
+        exitProcess(1)
+    }
+    exitProcess(0)
+}
+
+object Application {
+    private const val ENV_APPWRITE_ENDPOINT = "APPWRITE_ENDPOINT"
+    private const val ENV_APPWRITE_PROJECT = "APPWRITE_FUNCTION_PROJECT_ID"
+    private const val ENV_APPWRITE_KEY = "APPWRITE_API_KEY"
+    private const val ENV_APPWRITE_FUNCTION_DATA = "APPWRITE_FUNCTION_DATA"
+
+    private val jsonParser = Json { isLenient = true }
+
+    fun run() {
+        val client = Client()
+            .setEndpoint(getMandatoryEnv(ENV_APPWRITE_ENDPOINT))
+            .setProject(getMandatoryEnv(ENV_APPWRITE_PROJECT))
+            .setKey(getMandatoryEnv(ENV_APPWRITE_KEY))
+        val storage = Storage(client)
+
+        val functionData = System.getenv(ENV_APPWRITE_FUNCTION_DATA)
+            ?.let { jsonParser.decodeFromString<FunctionData>(it) }
+            ?: throw IllegalArgumentException("Function Data is required")
+        if (functionData.fileIds.isEmpty()) {
+            return
+        }
+
+        println(functionData)
+
+        val cloudConvert = CloudConvert()
+
+        val taskNamesToFileIds = functionData.fileIds.asSequence().mapIndexed { index, fileId ->
+            "${CloudConvert.TASK_PREFIX_UPLOAD}$index" to fileId
+        }.toMap()
+
+        val taskNamesToFiles = runBlocking {
+            taskNamesToFileIds.entries.asFlow()
+                .map { (taskId, fileId) -> taskId to storage.downloadFile(fileId) }
+                .toList()
+                .toMap()
+        }
+
+        val mergedFile = cloudConvert.merge(functionData, taskNamesToFiles)
+        println(storage.uploadFile(mergedFile))
+    }
+
+    private fun getMandatoryEnv(env: String): String {
+        return System.getenv(env)
+            ?: throw RuntimeException("Environment Variable not configured: $env")
+    }
+
+    @OptIn(ExperimentalSerializationApi::class) // required to use kotlinx.serialization's Json#decodeFromStream(InputStream)
+    private suspend fun Storage.downloadFile(fileId: String): AppwriteFile {
+        val fileMetadataResponse = getFile(fileId)
+        val fileMetadata = fileMetadataResponse.body?.byteStream()
+            ?.let { jsonParser.decodeFromStream<FileMetadata>(it) }
+            ?: throw RuntimeException("Error getting metadata for file in Appwrite Storage with ID $fileId: ${fileMetadataResponse.message}")
+        val fileDownloadResponse = getFileDownload(fileId)
+        val fileStream = fileDownloadResponse.body?.byteStream()
+            ?: throw RuntimeException("Error downloading file in Appwrite Storage with ID $fileId: ${fileDownloadResponse.message}")
+        return AppwriteFile(fileMetadata.name, fileStream)
+    }
+
+    @OptIn(ExperimentalSerializationApi::class) // required to use kotlinx.serialization's Json#decodeFromStream(InputStream)
+    private fun Storage.uploadFile(file: AppwriteFile): FileMetadata = runBlocking {
+        val createFileResponse = createFile(file.toFile())
+        createFileResponse.body
+            ?.let { jsonParser.decodeFromStream<FileMetadata>(it.byteStream()) }
+            ?: throw RuntimeException("Error creating file ${file.name} in Appwrite: ${createFileResponse.message}")
+    }
+}

--- a/kotlin/merge-cloud-convert-files/src/main/kotlin/io/appwrite/merge/cloud/convert/files/CloudConvert.kt
+++ b/kotlin/merge-cloud-convert-files/src/main/kotlin/io/appwrite/merge/cloud/convert/files/CloudConvert.kt
@@ -1,0 +1,79 @@
+package io.appwrite.merge.cloud.convert.files
+
+import com.cloudconvert.client.CloudConvertClient
+import com.cloudconvert.client.setttings.AbstractSettingsProvider
+import com.cloudconvert.dto.Operation
+import com.cloudconvert.dto.Status
+import com.cloudconvert.dto.request.MergeFilesTaskRequest
+import com.cloudconvert.dto.request.UploadImportRequest
+import com.cloudconvert.dto.request.UrlExportRequest
+import io.appwrite.merge.cloud.convert.files.model.AppwriteFile
+import io.appwrite.merge.cloud.convert.files.model.FunctionData
+import kotlin.system.exitProcess
+
+class CloudConvert {
+    companion object {
+        const val TASK_PREFIX_UPLOAD = "upload-import-"
+        private const val TASK_NAME_MERGE = "merge-files"
+        private const val TASK_NAME_DOWNLOAD = "url-export"
+    }
+
+    private val client = CloudConvertClient(object : AbstractSettingsProvider(
+        System.getenv(API_KEY),
+        "", // we are not using CloudConvert webhooks
+        System.getenv(USE_SANDBOX),
+    ) {})
+
+    fun merge(functionData: FunctionData, taskNamesToFiles: Map<String, AppwriteFile>): AppwriteFile {
+        val uploadTasks = taskNamesToFiles.keys.associateWith {
+            UploadImportRequest()
+        }
+
+        val tasks = mutableMapOf(
+            TASK_NAME_MERGE to MergeFilesTaskRequest()
+                .setInput(*uploadTasks.keys.toTypedArray())
+                .setOutputFormat("pdf")
+                .setEngine(functionData.engine)
+                .setEngineVersion(functionData.engineVersion)
+                .setFilename(functionData.outputFileName),
+            TASK_NAME_DOWNLOAD to UrlExportRequest()
+                .setInput(TASK_NAME_MERGE),
+        )
+        tasks.putAll(uploadTasks)
+
+        val createJobResponse = client.jobs().create(tasks)
+        val createdJob = createJobResponse.body
+            ?: throw RuntimeException("Error creating CloudConvert job: ${createJobResponse.message}")
+        createdJob.tasks
+            .parallelStream()   // cannot use coroutines to parallelize because CloudConvert client blocks the thread
+            .map { task -> task to taskNamesToFiles[task.name] }
+            .forEach { (task, file) ->
+                if (file != null) {
+                    val uploadResponse = client.importUsing().upload(task.id, task.result.form, file.stream, file.name)
+                    if (uploadResponse.status != 200) {
+                        System.err.println("Error uploading file ${file.name}: ${uploadResponse.message}")
+                    }
+                }
+            }
+
+        val finishedJob = client.jobs().wait(createdJob.id).body
+            ?: throw RuntimeException("Error waiting for CloudConvert job to finish: Empty response")
+        val downloadTask = finishedJob.tasks
+            .find { task -> task.operation == Operation.EXPORT_URL }
+            ?: throw RuntimeException("Error waiting for CloudConvert job to finish: No task with ${Operation.EXPORT_URL.label} operation")
+        if (downloadTask.status == Status.ERROR) {
+            finishedJob.tasks.asSequence()
+                .filter { task -> task.status == Status.ERROR }
+                .forEach { task -> System.err.println("Task ${task.name} failed with ${task.code} error: ${task.message}") }
+            exitProcess(1)
+        }
+        val downloadFileMetadata = downloadTask.result.files.first()
+        val downloadFileUrl = downloadFileMetadata["url"]
+            ?: throw RuntimeException("Error waiting for CloudConvert job to finish: No download url")
+        val downloadFileName = downloadFileMetadata["filename"]
+            ?: throw RuntimeException("Error waiting for CloudConvert job to finish: No download filename")
+        val downloadFileInputStream = client.files().download(downloadFileUrl).body
+            ?: throw RuntimeException("Error downloading file: Empty response")
+        return AppwriteFile(downloadFileName, downloadFileInputStream)
+    }
+}

--- a/kotlin/merge-cloud-convert-files/src/main/kotlin/io/appwrite/merge/cloud/convert/files/model/AppwriteFile.kt
+++ b/kotlin/merge-cloud-convert-files/src/main/kotlin/io/appwrite/merge/cloud/convert/files/model/AppwriteFile.kt
@@ -1,0 +1,17 @@
+package io.appwrite.merge.cloud.convert.files.model
+
+import java.io.File
+import java.io.FileOutputStream
+import java.io.InputStream
+
+data class AppwriteFile(
+    val name: String,
+    val stream: InputStream,
+) {
+    fun toFile(): File {
+        val file = File(name)
+        val downloadFileOutputStream = FileOutputStream(file)
+        stream.copyTo(downloadFileOutputStream)
+        return file
+    }
+}

--- a/kotlin/merge-cloud-convert-files/src/main/kotlin/io/appwrite/merge/cloud/convert/files/model/FunctionData.kt
+++ b/kotlin/merge-cloud-convert-files/src/main/kotlin/io/appwrite/merge/cloud/convert/files/model/FunctionData.kt
@@ -1,0 +1,11 @@
+package io.appwrite.merge.cloud.convert.files.model
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class FunctionData(
+    val fileIds: Collection<String>,
+    val engine: String? = null,
+    val engineVersion: String? = null,
+    val outputFileName: String? = null,
+)

--- a/kotlin/merge-cloud-convert-files/src/main/kotlin/io/appwrite/merge/cloud/convert/files/model/storage/FileMetadata.kt
+++ b/kotlin/merge-cloud-convert-files/src/main/kotlin/io/appwrite/merge/cloud/convert/files/model/storage/FileMetadata.kt
@@ -1,0 +1,14 @@
+package io.appwrite.merge.cloud.convert.files.model.storage
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class FileMetadata(
+    val `$id`: String,
+    val `$permissions`: Permissions,
+    val name: String,
+    val dateCreated: Int,
+    val signature: String,
+    val mimeType: String,
+    val sizeOriginal: Int,
+)

--- a/kotlin/merge-cloud-convert-files/src/main/kotlin/io/appwrite/merge/cloud/convert/files/model/storage/Permissions.kt
+++ b/kotlin/merge-cloud-convert-files/src/main/kotlin/io/appwrite/merge/cloud/convert/files/model/storage/Permissions.kt
@@ -1,0 +1,9 @@
+package io.appwrite.merge.cloud.convert.files.model.storage
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class Permissions(
+    val read: Collection<String>,
+    val write: Collection<String>,
+)


### PR DESCRIPTION
Partially implements appwrite/appwrite#1931

# Input
![image](https://user-images.githubusercontent.com/17351764/138812933-9204982d-8e76-4e06-91bd-d2be8d84908c.png)

# Successful Execution
![image](https://user-images.githubusercontent.com/17351764/139103832-dbc9a9aa-2e50-4178-9309-00212de68b08.png)

# CloudConvert Console
![image](https://user-images.githubusercontent.com/17351764/138813496-5223608a-7be4-48ea-a58d-c822f1a11b94.png)

# Output
![image](https://user-images.githubusercontent.com/17351764/138812996-b72988c0-c275-4f9d-9937-bada19181952.png)
- The Function Data is printed to the console
- The metadata of the merged PDF file is printed to the console

![image](https://user-images.githubusercontent.com/17351764/138865957-0ee2a1aa-62f5-48fc-8897-f725a79d39c0.png)

A few ways this improves over other Kotlin examples:
- Uses the [Gradle Shadow Plugin](https://imperceptiblethoughts.com/shadow/) to generate a uber/fat-JAR, and to minimize the JAR size (without it, just including the Kotlin standard library, [Appwrite SDK for Kotlin](https://github.com/appwrite/sdk-for-kotlin) and [CloudConvert Java SDK](https://github.com/cloudconvert/cloudconvert-java) would already exceed the 10MB size limit)
- Uses the [Gradle Application Plugin](https://docs.gradle.org/current/userguide/application_plugin.html) to build and create a TAR file in a single step (using `gradle shadowDistTar`), removing the need to manually TAR the JAR file
- Properly logs response messages on error from Appwrite/CloudConvert
- Uses coroutines to parallelize API calls. When not possible (eg. CloudConvert's client blocks the thread), falls back to Java parallel streams