### PR TITLE
generateGoogleMap(): Add Kotlin implementation

### DIFF
--- a/kotlin/generate-google-map/.gitignore
+++ b/kotlin/generate-google-map/.gitignore
@@ -1,0 +1,12 @@
+.gradle
+**/build/
+!src/**/build/
+
+# Ignore Gradle GUI config
+gradle-app.setting
+
+# Avoid ignoring Gradle wrapper jar file (.jar files are usually ignored)
+!gradle-wrapper.jar
+
+# Cache of project
+.gradletasknamecache

--- a/kotlin/generate-google-map/README.md
+++ b/kotlin/generate-google-map/README.md
@@ -1,0 +1,138 @@
+# 🦠 Generate Map Preview Using Google Maps
+
+A sample Kotlin Cloud Function for generating a map preview using Google Maps.
+
+## 📝 Environment Variables
+
+Go to Settings tab of your Cloud Function. Add the following environment variables.
+
+- **APPWRITE_ENDPOINT** - Mandatory. Your Appwrite Endpoint
+- **APPWRITE_API_KEY** - Mandatory. Your Appwrite API key with `files.write` permissions
+- **GOOGLEMAPS_API_KEY** - Mandatory. Your Google Maps API Key for Maps Static API. Created through Google Maps
+  Platform > Credentials on Google Cloud Platform
+
+## 🚀 Building and Packaging
+
+To package this example as a cloud function, follow these steps.
+
+- Create a tarfile
+
+```bash
+gradle shadowDistTar
+```
+
+(the tarfile is created in `build/distributions`)
+
+- Navigate to the Overview Tab of your Cloud Function > Deploy Tag
+- Input the command that will run your function (in this
+  case `java -jar lib/generate-google-map-1.0.0-SNAPSHOT-all.jar`) as your entrypoint command
+- Upload your tarfile
+- Click `Activate`
+
+## 🎯 Trigger
+
+Head over to your function in the Appwrite console and under the Overview Tab, click Execute Now and supply the function
+data in JSON format, eg.
+
+```json
+{
+  "outputFileName": "map.png",
+  "width": 600,
+  "height": 300,
+  "center": {
+    "latitude": 40.706086,
+    "longitude": -73.996864
+  },
+  "zoom": 13,
+  "mapType": "roadmap",
+  "markers": [
+    {
+      "color": "blue",
+      "label": "S",
+      "locations": [
+        {
+          "latitude": 40.702147,
+          "longitude": -74.015794
+        }
+      ]
+    },
+    {
+      "color": "green",
+      "label": "G",
+      "locations": [
+        {
+          "latitude": 40.711614,
+          "longitude": -74.012318
+        }
+      ]
+    },
+    {
+      "color": "red",
+      "label": "C",
+      "locations": [
+        {
+          "latitude": 40.718217,
+          "longitude": -73.998284
+        }
+      ]
+    }
+  ]
+}
+```
+
+### Parameters:
+
+- **outputFileName** - Mandatory. Name of output file (including extension).
+- **width** - Mandatory. The width of the map in pixels, when multiplied by the `scale` value
+- **height** - Mandatory. The height of the map in pixels, when multiplied by the `scale` value
+- **center** - Mandatory. Coordinates to center on. See `Coordinates` definition below
+- **zoom** - Optional. Required if `markers` or `path` is not present. The zoom level (
+  see https://developers.google.com/maps/documentation/maps-static/start#Zoomlevels for more information)
+- **scale** - Optional. Map size pixel multiplier. Defaults to `1`
+- **format** - Optional. The image format (
+  see https://developers.google.com/maps/documentation/maps-static/start#ImageFormats for the list of options)
+- **mapType** - Optional. Type of map to construct (
+  see https://developers.google.com/maps/documentation/maps-static/start#MapTypes for the list of options)
+- **region** - Optional. A region code, specified as a two-character ccTLD ('top-level domain') value. Defines the
+  appropriate borders to display, based on geo-political sensitivities
+- **markers** - Optional. A set of markers (map pins) at a set of locations. See `Marker` definition below
+- **paths** - Optional. A set of locations connected by a path to overlay on the map image. See `Path` definition below
+- **viewport** - Optional. Coordinates of a location to remain visible. See `Coordinates` definition below
+
+#### Marker
+
+- **size** - Optional. The size of marker (
+  see https://developers.google.com/maps/documentation/maps-static/start#MarkerStyles for the list of options)
+- **color** - Optional. A 24-bit color (example: `0xFFFFCC`) or a predefined color from the set (
+  see https://developers.google.com/maps/documentation/maps-static/start#MarkerStyles for the list of options)
+- **label** - Optional. A single uppercase alphanumeric character
+- **customIcon** - Optional. Custom icon for the marker. See `Custom Icon` definition below
+- **locations** - Mandatory. Coordinates of the marker. At least one is required. See `Coordinates` definition below
+
+##### Custom Icon
+
+- **url** - Mandatory. URL for the custom icon
+- **anchorPoint** - Mandatory. The anchor point for the custom icon (
+  see https://developers.google.com/maps/documentation/maps-static/start#CustomIcons for the list of options)
+- **scale** - Optional. The image density scale of the custom icon provided (
+  see https://developers.google.com/maps/documentation/maps-static/start#MarkerScale for the list of options)
+
+#### Path
+
+- **weight** - Optional. The thickness of the path in pixels. Defaults to `5` pixels.
+- **color** - Optional. A 24-bit color (example: `0xFFFFCC`) or a predefined color from the set (
+  see https://developers.google.com/maps/documentation/maps-static/start#PathStyles for the list of options)
+- **fillColor** - Optional. A 24-bit color (example: `0xFFFFCC`) or a predefined color from the set (
+  see https://developers.google.com/maps/documentation/maps-static/start#PathStyles for the list of options)
+- **geodesic** - Optional. If `true`, indicates that the requested path should be interpreted as a geodesic line that
+  follows the curvature of the earth. If `false`, the path is rendered as a straight line in screen space. Defaults
+  to `false`
+- **points** - Mandatory. Coordinates of the points to be connected. At least two are required. See `Coordinates`
+  definition below
+
+#### Coordinates
+
+- **latitude** - Mandatory. The latitude of the location. Must be between `-90` and `90`
+- **longitude** - Mandatory. The longitude of the location. Must be between `-180` and `180`
+
+See https://developers.google.com/maps/documentation/maps-static/start for more information.

--- a/kotlin/generate-google-map/build.gradle.kts
+++ b/kotlin/generate-google-map/build.gradle.kts
@@ -1,0 +1,42 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
+plugins {
+    kotlin("jvm") version "1.5.31"
+    kotlin("plugin.serialization") version "1.5.31"
+    application
+    id("com.github.johnrengelman.shadow") version "7.1.0"
+}
+
+group = "io.appwrite"
+version = "1.0.0-SNAPSHOT"
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation("io.appwrite:sdk-for-kotlin:0.1.0")
+    implementation("com.google.maps:google-maps-services:1.0.0")
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.3.0")
+    implementation("org.slf4j:slf4j-simple:1.7.32")
+}
+
+tasks.withType<KotlinCompile>().configureEach {
+    // required to use kotlinx.serialization's Json#decodeFromStream(InputStream)
+    kotlinOptions.freeCompilerArgs += "-Xopt-in=kotlin.RequiresOptIn"
+}
+
+application {
+    mainClass.set("io.appwrite.generate.google.map.ApplicationKt")
+}
+
+tasks.withType<Tar>() {
+    compression = Compression.GZIP
+    archiveExtension.set("tar.gz")
+}
+
+tasks {
+    shadowJar {
+        minimize ()
+    }
+}

--- a/kotlin/generate-google-map/gradle.properties
+++ b/kotlin/generate-google-map/gradle.properties
@@ -1,0 +1,1 @@
+kotlin.code.style=official

--- a/kotlin/generate-google-map/settings.gradle.kts
+++ b/kotlin/generate-google-map/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "generate-google-map"

--- a/kotlin/generate-google-map/src/main/kotlin/io/appwrite/generate/google/map/Application.kt
+++ b/kotlin/generate-google-map/src/main/kotlin/io/appwrite/generate/google/map/Application.kt
@@ -1,0 +1,61 @@
+package io.appwrite.generate.google.map
+
+import io.appwrite.Client
+import io.appwrite.generate.google.map.model.AppwriteFile
+import io.appwrite.generate.google.map.model.FunctionData
+import io.appwrite.generate.google.map.model.storage.FileMetadata
+import io.appwrite.generate.google.map.util.Env
+import io.appwrite.services.Storage
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.decodeFromStream
+import kotlin.system.exitProcess
+
+fun main() {
+    try {
+        Application.run()
+    } catch (exception: Exception) {
+        exception.printStackTrace()
+        exitProcess(1)
+    }
+    exitProcess(0)
+}
+
+object Application {
+    private const val ENV_APPWRITE_ENDPOINT = "APPWRITE_ENDPOINT"
+    private const val ENV_APPWRITE_PROJECT = "APPWRITE_FUNCTION_PROJECT_ID"
+    private const val ENV_APPWRITE_KEY = "APPWRITE_API_KEY"
+    private const val ENV_APPWRITE_FUNCTION_DATA = "APPWRITE_FUNCTION_DATA"
+
+    private val jsonParser = Json { isLenient = true }
+
+    fun run() {
+        val client = Client()
+            .setEndpoint(Env.getMandatory(ENV_APPWRITE_ENDPOINT))
+            .setProject(Env.getMandatory(ENV_APPWRITE_PROJECT))
+            .setKey(Env.getMandatory(ENV_APPWRITE_KEY))
+            .setSelfSigned(true)
+        val storage = Storage(client)
+
+        val googleMaps = GoogleMaps()
+
+        val functionData = System.getenv(ENV_APPWRITE_FUNCTION_DATA)
+            ?.let { jsonParser.decodeFromString<FunctionData>(it) }
+            ?: throw IllegalArgumentException("Function Data is required")
+        println(functionData)
+
+        val mapImage = googleMaps.generateMapImage(functionData)
+        val file = AppwriteFile(functionData.outputFileName, mapImage.inputStream())
+        println(storage.uploadFile(file))
+    }
+
+    @OptIn(ExperimentalSerializationApi::class) // required to use kotlinx.serialization's Json#decodeFromStream(InputStream)
+    private fun Storage.uploadFile(file: AppwriteFile): FileMetadata = runBlocking {
+        val createFileResponse = createFile(file.toFile())
+        createFileResponse.body
+            ?.let { jsonParser.decodeFromStream<FileMetadata>(it.byteStream()) }
+            ?: throw RuntimeException("Error creating file ${file.name} in Appwrite: ${createFileResponse.message}")
+    }
+}

--- a/kotlin/generate-google-map/src/main/kotlin/io/appwrite/generate/google/map/GoogleMaps.kt
+++ b/kotlin/generate-google-map/src/main/kotlin/io/appwrite/generate/google/map/GoogleMaps.kt
@@ -1,0 +1,56 @@
+package io.appwrite.generate.google.map
+
+import com.google.maps.GeoApiContext
+import com.google.maps.StaticMapsApi
+import com.google.maps.StaticMapsRequest
+import com.google.maps.model.LatLng
+import com.google.maps.model.Size
+import io.appwrite.generate.google.map.model.FunctionData
+import io.appwrite.generate.google.map.util.Env
+
+class GoogleMaps {
+    companion object {
+        private const val ENV_GOOGLEMAPS_API_KEY = "GOOGLEMAPS_API_KEY"
+    }
+
+    private val context = GeoApiContext.Builder()
+        .apiKey(Env.getMandatory(ENV_GOOGLEMAPS_API_KEY))
+        .build()
+
+    fun generateMapImage(functionData: FunctionData): ByteArray {
+        val request = StaticMapsApi.newRequest(context, Size(functionData.width, functionData.height))
+            .center(LatLng(functionData.center.latitude, functionData.center.longitude))
+        functionData.zoom?.let(request::zoom)
+        functionData.scale?.let(request::scale)
+        functionData.format?.let(request::format)
+        functionData.mapType?.let(request::maptype)
+        functionData.region?.let(request::region)
+        functionData.markers.map { markerData ->
+            StaticMapsRequest.Markers().apply {
+                size(markerData.size)
+                color(markerData.color)
+                markerData.label?.let { label(it.toString()) }
+                markerData.customIcon?.let {
+                    if (it.scale != null) {
+                        customIcon(it.url, it.anchorPoint, it.scale)
+                    } else {
+                        customIcon(it.url, it.anchorPoint)
+                    }
+                }
+                markerData.locations.forEach { addLocation(LatLng(it.latitude, it.longitude)) }
+            }
+        }.forEach(request::markers)
+        functionData.paths.map { pathData ->
+            StaticMapsRequest.Path().apply {
+                pathData.weight?.let { weight(it) }
+                color(pathData.color)
+                fillcolor(pathData.fillColor)
+                pathData.geodesic?.let { geodesic(it) }
+                pathData.points.forEach { addPoint(LatLng(it.latitude, it.longitude)) }
+            }
+        }.forEach(request::path)
+        functionData.viewport?.let { request.visible(LatLng(it.latitude, it.longitude)) }
+
+        return request.await().imageData
+    }
+}

--- a/kotlin/generate-google-map/src/main/kotlin/io/appwrite/generate/google/map/model/AppwriteFile.kt
+++ b/kotlin/generate-google-map/src/main/kotlin/io/appwrite/generate/google/map/model/AppwriteFile.kt
@@ -1,0 +1,17 @@
+package io.appwrite.generate.google.map.model
+
+import java.io.File
+import java.io.FileOutputStream
+import java.io.InputStream
+
+data class AppwriteFile(
+    val name: String,
+    val stream: InputStream,
+) {
+    fun toFile(): File {
+        val file = File(name)
+        val downloadFileOutputStream = FileOutputStream(file)
+        stream.copyTo(downloadFileOutputStream)
+        return file
+    }
+}

--- a/kotlin/generate-google-map/src/main/kotlin/io/appwrite/generate/google/map/model/FunctionData.kt
+++ b/kotlin/generate-google-map/src/main/kotlin/io/appwrite/generate/google/map/model/FunctionData.kt
@@ -1,0 +1,108 @@
+@file:UseSerializers(
+    ImageFormatSerializer::class,
+    MapTypeSerializer::class,
+    MarkerSizeSerializer::class,
+    MarkerCustomIconAnchorPointSerializer::class,
+)
+
+package io.appwrite.generate.google.map.model
+
+import com.google.maps.StaticMapsRequest
+import com.google.maps.internal.StringJoin
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.UseSerializers
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import java.util.*
+import kotlin.reflect.KClass
+
+@Serializable
+data class FunctionData(
+    val outputFileName: String,
+    val width: Int,
+    val height: Int,
+    val center: Coordinates,
+    val zoom: Int? = null,
+    val scale: Int? = null,
+    val format: StaticMapsRequest.ImageFormat? = null,
+    val mapType: StaticMapsRequest.StaticMapType? = null,
+    val region: String? = null,
+    val markers: Collection<Marker> = emptyList(),
+    val paths: Collection<Path> = emptyList(),
+    val viewport: Coordinates? = null,
+)
+
+@Serializable
+data class Coordinates(
+    val latitude: Double,
+    val longitude: Double,
+)
+
+@Serializable
+data class Marker(
+    val size: StaticMapsRequest.Markers.MarkersSize? = null,
+    val color: String? = null,
+    val label: Char? = null,
+    val customIcon: MarkerCustomIcon? = null,
+    val locations: Collection<Coordinates> = emptyList()
+)
+
+@Serializable
+data class MarkerCustomIcon(
+    val url: String,
+    val anchorPoint: StaticMapsRequest.Markers.CustomIconAnchor,
+    val scale: Int? = null,
+)
+
+@Serializable
+data class Path(
+    val weight: Int? = null,
+    val color: String? = null,
+    val fillColor: String? = null,
+    val geodesic: Boolean? = null,
+    val points: Collection<Coordinates> = emptyList()
+)
+
+object ImageFormatSerializer : UrlValueEnumSerializer<StaticMapsRequest.ImageFormat>(
+    FunctionData::format.name,
+    StaticMapsRequest.ImageFormat::class,
+)
+
+object MapTypeSerializer : UrlValueEnumSerializer<StaticMapsRequest.StaticMapType>(
+    FunctionData::mapType.name,
+    StaticMapsRequest.StaticMapType::class,
+)
+
+object MarkerSizeSerializer : UrlValueEnumSerializer<StaticMapsRequest.Markers.MarkersSize>(
+    "${FunctionData::markers.name}.${Marker::size.name}",
+    StaticMapsRequest.Markers.MarkersSize::class,
+)
+
+object MarkerCustomIconAnchorPointSerializer : UrlValueEnumSerializer<StaticMapsRequest.Markers.CustomIconAnchor>(
+    "${FunctionData::markers.name}.${Marker::customIcon.name}.${MarkerCustomIcon::anchorPoint.name}",
+    StaticMapsRequest.Markers.CustomIconAnchor::class,
+)
+
+sealed class UrlValueEnumSerializer<T>(
+    private val parameterName: String,
+    enumClass: KClass<T>,
+) : KSerializer<T> where T : Enum<T>, T : StringJoin.UrlValue {
+    private val urlValuesToEnums = EnumSet.allOf(enumClass.java)
+        .associateBy { it.toUrlValue() }
+
+    override val descriptor = PrimitiveSerialDescriptor(enumClass.simpleName!!, PrimitiveKind.STRING)
+
+    override fun serialize(encoder: Encoder, value: T) {
+        encoder.encodeString(value.toUrlValue())
+    }
+
+    override fun deserialize(decoder: Decoder): T {
+        val urlValue = decoder.decodeString()
+        return urlValuesToEnums[urlValue]
+            ?: throw SerializationException("$parameterName should be one of ${urlValuesToEnums.keys}")
+    }
+}

--- a/kotlin/generate-google-map/src/main/kotlin/io/appwrite/generate/google/map/model/storage/FileMetadata.kt
+++ b/kotlin/generate-google-map/src/main/kotlin/io/appwrite/generate/google/map/model/storage/FileMetadata.kt
@@ -1,0 +1,14 @@
+package io.appwrite.generate.google.map.model.storage
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class FileMetadata(
+    val `$id`: String,
+    val `$permissions`: Permissions,
+    val name: String,
+    val dateCreated: Int,
+    val signature: String,
+    val mimeType: String,
+    val sizeOriginal: Int,
+)

--- a/kotlin/generate-google-map/src/main/kotlin/io/appwrite/generate/google/map/model/storage/Permissions.kt
+++ b/kotlin/generate-google-map/src/main/kotlin/io/appwrite/generate/google/map/model/storage/Permissions.kt
@@ -1,0 +1,9 @@
+package io.appwrite.generate.google.map.model.storage
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class Permissions(
+    val read: Collection<String>,
+    val write: Collection<String>,
+)

--- a/kotlin/generate-google-map/src/main/kotlin/io/appwrite/generate/google/map/util/Env.kt
+++ b/kotlin/generate-google-map/src/main/kotlin/io/appwrite/generate/google/map/util/Env.kt
@@ -1,0 +1,8 @@
+package io.appwrite.generate.google.map.util
+
+object Env {
+    fun getMandatory(env: String): String {
+        return System.getenv(env)
+            ?: throw RuntimeException("Environment Variable not configured: $env")
+    }
+}


### PR DESCRIPTION
Partially implements appwrite/appwrite#1905

![image](https://user-images.githubusercontent.com/17351764/139099518-2e62aa54-f05d-4a30-ae60-4a7b2dbb7e1e.png)
![image](https://user-images.githubusercontent.com/17351764/139099558-afce3976-2df3-466a-b4eb-1fc6dc3077a6.png)
- Note that I've included support for all parameters, including markers (as seen in the screenshot) and paths.

# Input
![image](https://user-images.githubusercontent.com/17351764/139099803-40f0f96a-d42a-4451-bd12-63a9fae8a74f.png)

# Successful Execution
![image](https://user-images.githubusercontent.com/17351764/139099755-2e1af8f5-834a-4383-9331-e17333ec686a.png)

# Output
![image](https://user-images.githubusercontent.com/17351764/139099958-50f98aba-56a1-4079-953c-c49ec1b4e2bd.png)
- The Function Data is printed to the console
- The metadata of the map image file is printed to the console

A few ways this improves over other Kotlin examples:
- Uses the [Gradle Shadow Plugin](https://imperceptiblethoughts.com/shadow/) to generate a uber/fat-JAR, and to minimize the JAR size (without it, just including the Kotlin standard library, [Appwrite SDK for Kotlin](https://github.com/appwrite/sdk-for-kotlin) and [CloudConvert Java SDK](https://github.com/cloudconvert/cloudconvert-java) would already exceed the 10MB size limit)
- Uses the [Gradle Application Plugin](https://docs.gradle.org/current/userguide/application_plugin.html) to build and create a TAR file in a single step (using `gradle shadowDistTar`), removing the need to manually TAR the JAR file
- Validates enum values and displays possible options in error message