### PR TITLE
feat: Implement createdAt cloud function in PHP

### DIFF
--- a/php/add-created-at/README.md
+++ b/php/add-created-at/README.md
@@ -1,0 +1,51 @@
+# Add createdAt Timestamp when document created
+
+A sample PHP Cloud Function that trigger on `database.documents.create` event and fill `createdAt` attribute with the current time, if this rule for `createdAt` is configured on a specific collection.
+
+## 📝 Environment Variables
+
+Go to Settings tab of your Cloud Function. Add the following environment variables.
+
+- **APPWRITE_ENDPOINT** - Your Appwrite Project Endpoint ( can be found at `settings` tab on your Appwrite console)
+- **APPWRITE_API_KEY** - Your Appwrite Project API Keys ( can be found at `API Keys` tab on your Appwrite console)
+
+## 🚀 Building and Packaging
+
+To package this example as a cloud function, follow these steps.
+
+```bash
+$ cd demos-for-functions/php/add-created-at
+
+$ tar -zcvf code.tar.gz .
+```
+
+- Navigate to the Overview Tab of your Cloud Function > Deploy Tag
+- Input the command that will run your function (in this case `php index.php`) as your entrypoint command
+- Upload your tarfile
+- Click 'Activate'
+
+## 🎯 Trigger
+
+- Head over to your function in the Appwrite console, then add new function with PHP Runtimes
+- under created functions Settings Tab, scroll down to variables section and add all the Environment Variables above.
+- check the `database.document.create` event. After that the function will automatically trigger when a new document is created (see the Database section to learn how to create & update document).
+
+## 💽 Database
+
+Go to Database tab and follow these steps:
+
+- Add new Collection, then database collection settings will popup
+- At the Rules section, click add
+- fill `createdAt` as the key & label
+- set the Rule Type to text and click create
+- update the settings by clicking update button
+- Go to Documents tab and click add document
+- fill in the data needed and click create
+- after you create a document. the create button will convert to update button
+- fill new data and click update and the cloud function will trigger
+
+PS: You can add as many rules as wanted, we just need `createdAt` key to see the cloud functions working
+
+## 📓 Note
+
+- if `APPWRITE_ENDPOINT` is localhost, error will occur `Fatal error: Uncaught Appwrite\AppwriteException: Failed to connect to localhost port 80: Connection refused in /usr/local/src/vendor/appwrite/appwrite/src/Appwrite/Client.php:225`. It happenedd because 127.0.0.1 is not recognized, use your current network ip instead (by using `ipconfig` on windows, or see your network preferences on mac).

--- a/php/add-created-at/composer.json
+++ b/php/add-created-at/composer.json
@@ -1,0 +1,15 @@
+{
+    "name": "demos-for-functions/add-created-at",
+    "description": "A sample PHP Cloud Function that fill createdAt attribute with current time",
+    "type": "library",
+    "license": "BSD-3-Clause",
+    "authors": [
+      {
+        "name": "Team Appwrite",
+        "email": "team@appwrite.io"
+      }
+    ],
+    "require": {
+      "appwrite/appwrite": "2.1.*"
+    }
+  }

--- a/php/add-created-at/index.php
+++ b/php/add-created-at/index.php
@@ -1,0 +1,35 @@
+<?php
+
+include './vendor/autoload.php';
+use Appwrite\Client;
+use Appwrite\Services\Database;
+
+
+
+$appwriteEndpoint = $_ENV['APPWRITE_ENDPOINT'];
+$appwriteProjectId = $_ENV['APPWRITE_FUNCTION_PROJECT_ID'];
+$appwriteAPIKey = $_ENV['APPWRITE_API_KEY'];
+
+$client = new Client();
+$client
+    ->setEndpoint($appwriteEndpoint)
+    ->setProject($appwriteProjectId)
+    ->setKey($appwriteAPIKey);
+
+$database = new Database($client);
+
+$data = array("createdAt" => date(DATE_ISO8601,time()));
+
+$payload = get_object_vars(json_decode($_ENV['APPWRITE_FUNCTION_EVENT_DATA'])); 
+
+if (!array_key_exists('createdAt', $payload)){
+    echo("Rule for createdAt has not been created in the collection!");
+    return;
+} 
+$collectionId = $payload['$collection'];
+$documentId = $payload['$id'];
+
+$result = $database->updateDocument($collectionId, $documentId, $data);
+
+print_r(json_encode($result)); 
+


### PR DESCRIPTION
Addresses https://github.com/appwrite/appwrite/issues/1899
# creating document
<img width="654" alt="create_document" src="https://user-images.githubusercontent.com/30474195/139323437-bac88189-a9ca-4ea5-b09d-89db1edb4d7b.PNG">


# document after creation
<img width="722" alt="document" src="https://user-images.githubusercontent.com/30474195/139323497-bd695d8e-a951-40c6-9b46-ae023014b881.PNG">

# function execution log

<img width="751" alt="createdAt_logs" src="https://user-images.githubusercontent.com/30474195/139323548-f21e5659-a12c-45ed-af5a-794547a7d1ac.PNG">

# function output

<img width="622" alt="createdAt_stdout" src="https://user-images.githubusercontent.com/30474195/139323582-dd455eb6-7e9e-4ac2-8868-5f1893128994.PNG">


