### PR TITLE
Implement get internet speed demo function in Python

### DIFF
--- a/python/get-internet-speed/README.md
+++ b/python/get-internet-speed/README.md
@@ -1,0 +1,49 @@
+## 📧 Function for getting internet speed
+A sample Python Cloud Function to check the download and upload speed (and related statistics) of the server.
+
+## 📝 Environment Variables
+No environment variables needed.
+  
+🚀 Building and Packaging
+To package this example as a cloud function, follow these steps.
+
+```bash
+$ cd demos-for-functions/python/get-internet-speed
+
+$ PIP_TARGET=./.appwrite pip install -r ./requirements.txt --upgrade --ignore-installed 
+```
+
+* Ensure that your folder structure looks like this 
+```
+.
+├── .appwrite/
+├── main.py
+├── README.md
+└── requirements.txt
+```
+
+* Create a tarfile
+
+```bash
+$ cd ..
+$ tar -zcvf code.tar.gz get-internet-speed
+```
+
+* Upload the tarfile to your Appwrite Console and use the following entrypoint command
+
+```bash
+python main.py
+```
+
+* Click 'Activate'
+* Increase the timeout for the function to at least 120 sec or more (in Function setting > Timeout field).
+* Depending on the location and the server's speed, you will need to adjust the timeout accordingly.
+
+## 🎯 Trigger
+After the Building and Packaging step, follow the following steps:
+
+1. Press the Execute Now button.
+2. Wait for the function to finish
+3. Check the Logs for the result
+Example output: `{'download_speed': '45.07 Mbps', 'upload_speed': '61.02 Mbps', 'ping': '7.274 ms'}`
+

--- a/python/get-internet-speed/README.md
+++ b/python/get-internet-speed/README.md
@@ -1,4 +1,4 @@
-## 📧 Function for getting internet speed
+## 📡 Function for getting internet speed
 A sample Python Cloud Function to check the download and upload speed (and related statistics) of the server.
 
 ## 📝 Environment Variables

--- a/python/get-internet-speed/main.py
+++ b/python/get-internet-speed/main.py
@@ -1,0 +1,15 @@
+from speedtest import Speedtest
+
+s = Speedtest()
+s.download()
+s.upload()
+
+results_dict = s.results.dict()
+
+pretty_results_dict = {
+    "download_speed": f"{(results_dict['download'] / 1000.0 / 1000.0):.2f} Mbps",
+    "upload_speed": f"{(results_dict['upload'] / 1000.0 / 1000.0):.2f} Mbps",
+    "ping": f"{results_dict['ping']} ms",
+}
+
+print(pretty_results_dict)

--- a/python/get-internet-speed/requirements.txt
+++ b/python/get-internet-speed/requirements.txt
@@ -1,0 +1,1 @@
+speedtest-cli


### PR DESCRIPTION
Implemented function to get internet speed using [`speedtest-cli`](https://github.com/sivel/speedtest-cli). 
Part of appwrite/appwrite#1910.

**Execution screenshot**
![image](https://user-images.githubusercontent.com/29891001/147131756-4e6bd12b-f732-412f-a70d-1359bcab7e71.png)

I opened a PR for this issue (even though it was assigned to someone else) because it's been a long time since there was any activity there :sweat_smile: 